### PR TITLE
高版本JDK需要额外配置，才能避免Maven报错

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## 通过 Maven 安装(推荐)
 通过 Maven 获取安装是使用 JAVA SDK 的推荐方法，Maven 是 JAVA 的依赖管理工具，支持您项目所需的依赖项，并将其安装到项目中。关于 Maven 详细可参考 Maven 官网 。
 1. 请访问[Maven官网](https://maven.apache.org/)下载对应系统Maven安装包进行安装。
-2. 为您的项目添加 Maven 依赖项，只需在 Maven pom.xml 添加以下依赖项即可。**注意这里的版本号只是举例,您可以在[Maven仓库](https://search.maven.org/search?q=tencentcloud-sdk-java)上找到最新的版本。**：
+2. 为您的项目添加 Maven 依赖项，只需在 Maven pom.xml 添加以下依赖项即可。**注意这里的版本号只是举例,您可以在[Maven仓库](https://search.maven.org/search?q=tencentcloud-sdk-java)上找到最新的版本。**
 ```xml
 <dependency>
 	<groupId>com.tencentcloudapi</groupId>
@@ -19,6 +19,14 @@
     <!-- go to https://search.maven.org/search?q=tencentcloud-sdk-java and get the latest version. -->
 	<version>3.0.67</version>
 </dependency>
+```
+  如果JDK版本为JDK 9及以上，需要在pom.xml文件中添加如下配置：
+```xml
+<properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+</properties>
 ```
 3. 引用方法可参考示例。
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 ```xml
 <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
 </properties>
 ```
 3. 引用方法可参考示例。


### PR DESCRIPTION
经过实验，JDK 8按照现有教程的部署安装会成功。
但是JDK 9版本，会报如下错误：
Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project face: Compilation failure: Compilation failure:

此问题的解决方案是在pom.xml文件中添加如下配置：
<properties>
    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
    <maven.compiler.source>1.8</maven.compiler.source>
    <maven.compiler.target>1.8</maven.compiler.target>
</properties>