### PR TITLE
【安全】升级 okhttp 3.12.13 -> 4.12.0，修复 CVE-2021-0341 和 CVE-2023-3635

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,29 @@ cpf.getHttpProfile().setHttpClient(...);
 
 请注意，从 3.0.x 版本升级到 3.1.x 版本有兼容性问题，对于 Integer 字段的使用修改为了 Long 类型，需要重新编译项目。
 
+## OkHttp 升级
+
+为规避 OkHttp 3.x 版本存在的安全风险，从版本 3.2.0 起，OkHttp 依赖由 3.12.13 升级至 4.12.0。
+
+### 回退至 OkHttp 3.12.13
+
+若升级后与项目存在冲突，可在应用 `pom.xml` 中显式声明以下依赖进行回退。依据 Maven “路径最近优先”的依赖仲裁规则，应用声明的版本将覆盖 SDK 传递引入的 4.12.0：
+
+```xml
+<dependency>
+  <groupId>com.squareup.okhttp3</groupId>
+  <artifactId>okhttp</artifactId>
+  <version>3.12.13</version>
+</dependency>
+<dependency>
+  <groupId>com.squareup.okhttp3</groupId>
+  <artifactId>logging-interceptor</artifactId>
+  <version>3.12.13</version>
+</dependency>
+```
+
+> **注意**：回退操作将重新引入旧版 OkHttp 已修复的安全风险，仅可用于故障应急与问题定位，问题排除后应尽快恢复使用 OkHttp 4。
+
 ## 证书问题
 
 证书问题通常是客户端环境配置错误导致的。SDK 没有对证书进行操作，依赖的是 Java 运行环境本身的处理。出现证书问题后，可以使用`-Djavax.net.debug=ssl`开启详细日志辅助判断。

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.12.13</version>
+      <version>4.12.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
-      <version>3.12.13</version>
+      <version>4.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/tencentcloudapi/common/AbstractClient.java
+++ b/src/main/java/com/tencentcloudapi/common/AbstractClient.java
@@ -398,7 +398,8 @@ public abstract class AbstractClient {
         conn.setProxy(proxy);
 
         final String username = this.profile.getHttpProfile().getProxyUsername();
-        final String password = this.profile.getHttpProfile().getProxyPassword();
+        String configuredPassword = this.profile.getHttpProfile().getProxyPassword();
+        final String password = configuredPassword == null ? "" : configuredPassword;
         if (username == null || username.isEmpty()) {
             return;
         }

--- a/src/test/java/com/tencentcloudapi/common/AbstractClientProxyAuthTest.java
+++ b/src/test/java/com/tencentcloudapi/common/AbstractClientProxyAuthTest.java
@@ -1,0 +1,120 @@
+package com.tencentcloudapi.common;
+
+import com.tencentcloudapi.common.http.HttpConnection;
+import com.tencentcloudapi.common.profile.ClientProfile;
+import com.tencentcloudapi.common.profile.HttpProfile;
+import okhttp3.Authenticator;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Unit tests for the proxy authentication setup in {@link AbstractClient}.
+ *
+ * <p>Regression coverage for the okhttp 3.x -> 4.x upgrade: okhttp 4's
+ * {@code Credentials.basic(username, password)} rejects a null password with an NPE,
+ * so {@code AbstractClient.trySetProxy} now falls back to an empty password when the
+ * profile only configures a proxy username.
+ */
+public class AbstractClientProxyAuthTest {
+
+    /**
+     * Minimal concrete subclass: AbstractClient declares no abstract methods, so an empty
+     * subclass is enough to instantiate it. The constructor performs no network I/O.
+     */
+    private static final class TestClient extends AbstractClient {
+        TestClient(ClientProfile profile) {
+            super("cvm.tencentcloudapi.com", "2017-03-12",
+                    new Credential("secret-id", "secret-key"), "ap-guangzhou", profile);
+        }
+    }
+
+    private static ClientProfile proxyProfile(String username, String password) {
+        HttpProfile httpProfile = new HttpProfile();
+        httpProfile.setProxyHost("127.0.0.1");
+        httpProfile.setProxyPort(8080);
+        if (username != null) {
+            httpProfile.setProxyUsername(username);
+        }
+        if (password != null) {
+            httpProfile.setProxyPassword(password);
+        }
+        ClientProfile profile = new ClientProfile();
+        profile.setHttpProfile(httpProfile);
+        return profile;
+    }
+
+    private static OkHttpClient extractOkHttpClient(AbstractClient client) throws Exception {
+        Field connField = AbstractClient.class.getDeclaredField("httpConnection");
+        connField.setAccessible(true);
+        HttpConnection conn = (HttpConnection) connField.get(client);
+        Field clientField = HttpConnection.class.getDeclaredField("client");
+        clientField.setAccessible(true);
+        return (OkHttpClient) clientField.get(conn);
+    }
+
+    private static Response fakeProxyChallenge() {
+        Request request = new Request.Builder()
+                .url("https://cvm.tencentcloudapi.com/")
+                .build();
+        return new Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(407)
+                .message("Proxy Authentication Required")
+                .build();
+    }
+
+    /**
+     * The core regression: with only a proxy username configured (password is null), the
+     * authenticator must not throw on okhttp 4, and must send an empty password.
+     * base64("user:") = "dXNlcjo=".
+     */
+    @Test
+    public void nullProxyPasswordFallsBackToEmpty() throws Exception {
+        OkHttpClient ok = extractOkHttpClient(new TestClient(proxyProfile("user", null)));
+        Authenticator authenticator = ok.proxyAuthenticator();
+        Request authenticated = authenticator.authenticate(null, fakeProxyChallenge());
+        assertEquals("Basic dXNlcjo=", authenticated.header("Proxy-Authorization"));
+    }
+
+    /**
+     * A configured password must be passed through unchanged.
+     * base64("user:pass") = "dXNlcjpwYXNz".
+     */
+    @Test
+    public void configuredProxyPasswordIsUsed() throws Exception {
+        OkHttpClient ok = extractOkHttpClient(new TestClient(proxyProfile("user", "pass")));
+        Authenticator authenticator = ok.proxyAuthenticator();
+        Request authenticated = authenticator.authenticate(null, fakeProxyChallenge());
+        assertEquals("Basic dXNlcjpwYXNz", authenticated.header("Proxy-Authorization"));
+    }
+
+    /**
+     * Proxy host configured but no username: no authenticator should be installed
+     * (okhttp default is Authenticator.NONE).
+     */
+    @Test
+    public void proxyWithoutUsernameKeepsDefaultAuthenticator() throws Exception {
+        OkHttpClient ok = extractOkHttpClient(new TestClient(proxyProfile(null, "pass")));
+        assertSame(Authenticator.NONE, ok.proxyAuthenticator());
+    }
+
+    /**
+     * No proxy configured at all: neither proxy nor authenticator should be installed.
+     */
+    @Test
+    public void noProxyKeepsDefaults() throws Exception {
+        OkHttpClient ok = extractOkHttpClient(new TestClient(new ClientProfile()));
+        assertSame(Authenticator.NONE, ok.proxyAuthenticator());
+        assertNull(ok.proxy());
+    }
+}


### PR DESCRIPTION
- pom.xml: okhttp 和 logging-interceptor 升级至 4.12.0
- AbstractClient: proxy 密码为 null 时回退为空字符串，规避 okhttp 4 Credentials.basic 的 NPE
- README: 新增 OkHttp 升级说明与回退指引
- 新增 AbstractClientProxyAuthTest 覆盖代理认证回归场景